### PR TITLE
Add no shipping option

### DIFF
--- a/lib/paypal_express/api.rb
+++ b/lib/paypal_express/api.rb
@@ -317,6 +317,7 @@ module Killbill #:nodoc:
         options[:return_url] = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_hash, :return_url)
         options[:cancel_return_url] = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_hash, :cancel_return_url)
         options[:payment_processor_account_id] = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_hash, :payment_processor_account_id)
+        options[:no_shipping] = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_hash, :no_shipping)
 
         max_amount_value = ::Killbill::Plugin::ActiveMerchant::Utils.normalized(properties_hash, :max_amount)
         if max_amount_value


### PR DESCRIPTION
@pierre Please review. This PR added a no_shipping option in SetExpressCheckout Call which determines whether the shipping information is shown on the PayPal page. FYI: [no_shipping on ActiveMerchant](https://github.com/activemerchant/active_merchant/blob/4b44b9aceb2e54d1d9e8f591643b4f1facd37ec0/lib/active_merchant/billing/gateways/paypal_express.rb#L136) and [SetExpressCheckout](https://developer.paypal.com/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/)