### PR TITLE
Use Payment failure as status for canceled pending transactions 

### DIFF
--- a/lib/paypal_express/models/response.rb
+++ b/lib/paypal_express/models/response.rb
@@ -82,7 +82,7 @@ module Killbill #:nodoc:
                 :kb_payment_id => transaction_plugin_info.kb_payment_id,
                 :kb_payment_transaction_id => transaction_plugin_info.kb_transaction_payment_id).update_all( :success => false,
                                                                                                              :updated_at => Time.now.utc,
-                                                                                                             :message => { :payment_plugin_status => :CANCELED, :exception_message => 'Token expired. Payment Canceled by Janitor.' }.to_json)
+                                                                                                             :message => { :payment_plugin_status => :ERROR, :exception_message => 'Token expired. Payment Canceled by Janitor.' }.to_json)
       end
 
       def to_transaction_info_plugin(transaction=nil)

--- a/spec/paypal_express/remote/hpp_spec.rb
+++ b/spec/paypal_express/remote/hpp_spec.rb
@@ -328,7 +328,7 @@ shared_examples 'hpp_spec_common' do
     payment_infos[0].kb_payment_id.should == kb_payment_id
     payment_infos[0].amount.should be_nil
     payment_infos[0].currency.should be_nil
-    payment_infos[0].status.should == :CANCELED
+    payment_infos[0].status.should == :ERROR
     payment_infos[0].gateway_error.should == 'Token expired. Payment Canceled by Janitor.'
     payment_infos[0].gateway_error_code.should be_nil
   end
@@ -365,7 +365,7 @@ shared_examples 'hpp_spec_common' do
     payment_infos[0].kb_payment_id.should == kb_payment_id
     payment_infos[0].amount.should be_nil
     payment_infos[0].currency.should be_nil
-    payment_infos[0].status.should == :CANCELED
+    payment_infos[0].status.should == :ERROR
     payment_infos[0].gateway_error.should == 'Token expired. Payment Canceled by Janitor.'
     payment_infos[0].gateway_error_code.should be_nil
   end

--- a/spec/paypal_express/remote/hpp_spec.rb
+++ b/spec/paypal_express/remote/hpp_spec.rb
@@ -331,6 +331,7 @@ shared_examples 'hpp_spec_common' do
     payment_infos[0].status.should == :ERROR
     payment_infos[0].gateway_error.should == 'Token expired. Payment Canceled by Janitor.'
     payment_infos[0].gateway_error_code.should be_nil
+    @plugin.kb_apis.proxied_services[:payment_api].get_payment(kb_payment_id).transactions.first.transaction_status == 'PAYMENT_FAILURE'
   end
 
   it 'should cancel the pending payment if the token expires without passing property' do
@@ -368,6 +369,7 @@ shared_examples 'hpp_spec_common' do
     payment_infos[0].status.should == :ERROR
     payment_infos[0].gateway_error.should == 'Token expired. Payment Canceled by Janitor.'
     payment_infos[0].gateway_error_code.should be_nil
+    @plugin.kb_apis.proxied_services[:payment_api].get_payment(kb_payment_id).transactions.first.transaction_status == 'PAYMENT_FAILURE'
   end
 end
 


### PR DESCRIPTION
@pierre This is to change the status from `:CANCELED` to `:ERROR` for those pending transactions that are cleaned up by Janitor after the token expires.  `PAYMENT_FAILURE`, which indicates some 'normal' payment failures, sounds to be more reasonable compared with `PLUGIN_FAILURE`  

```
Finished in 14 minutes 50.8 seconds
29 examples, 0 failures